### PR TITLE
Allow for pip install -r requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
-python
 numpy
 torch==1.4.0
-pickle
-argparse
-time
 scikit-learn
 matplotlib
-os


### PR DESCRIPTION
Several requirements in the original requirements.txt are part of the standard Python library.
This means they are always present, and the main issue is that they cause a crash when
installing the requirements with the common `pip install -r requirements.txt` syntax